### PR TITLE
Disk check was done on undefined member

### DIFF
--- a/lib/retention-guard.js
+++ b/lib/retention-guard.js
@@ -106,7 +106,7 @@ internals.RetentionGuard.prototype.removeOld = function(callback){
     }
 
     if (self.minFreeSpace) {
-        Disk.check(self.dir, function(err,info){
+        Disk.check(self._dir, function(err,info){
             if (err){
                 return callback(err);
             }


### PR DESCRIPTION
Instead of testing on inner member self._dir, tested on undefined
variable (self.dir)
